### PR TITLE
feat: Read repo list from env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This repo hosts all useful links of databend.
 
+Click the button below to deploy on Vercel.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fdatafuselabs%2Flink&env=GITHUB_REPOS,GITHUB_TOKEN&envDescription=Environment%20Variables%20Reference&envLink=https%3A%2F%2Fgithub.com%2Fdatafuselabs%2Flink%23environment-variables)
+
+## Environment Variables
+
+- `GITHUB_TOKEN`: Github personal access token with read access.
+- `GITHUB_REPOS`: Github repositories separated by comma, e.g. `datafuselabs/databend,datafuselabs/opendal`.
+
 Please report to us via [issues](https://github.com/datafuselabs/link/issues) while meeting any link broken.
 
 ## Current

--- a/api/good_first_issue_test.go
+++ b/api/good_first_issue_test.go
@@ -3,12 +3,14 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 )
 
 func TestGoodFirstIssue(t *testing.T) {
 	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
 	// pass 'nil' as the third parameter.
+	os.Setenv("GITHUB_REPOS", "datafuselabs/databend,datafuselabs/opendal")
 	req, err := http.NewRequest("GET", "/", nil)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Change Summary

1. Read repository list from environment variables instead of hard coding.
2. Add Vercel deploy button.
3. Return 404 error if no issues are found.

With this change, other communities can create their own "link" service with a _single_ click.

To keep the app working as before, you might need to set `GITHUB_REPOS` to `datafuselabs/databend,datafuselabs/openraft,datafuselabs/opendal` in the current vercel app.