### PR TITLE
Add Deploy to PandaStack button

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repo hosts all useful links of databend.
 Click the button below to deploy on Vercel.
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fdatabendlabs%2Flink&env=GITHUB_REPOS,GITHUB_TOKEN&envDescription=Environment%20Variables%20Reference&envLink=https%3A%2F%2Fgithub.com%2Fdatabendlabs%2Flink%23environment-variables)
+[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=databendlabs/link&type=static&buildCmd=npm+run+build&outputDir=dist)
 
 ## Environment Variables
 


### PR DESCRIPTION
<img src="https://pandastack.io/logo.png" alt="PandaStack" height="40"/>

## Add Deploy to PandaStack button

This PR adds a **[Deploy to PandaStack](https://pandastack.io)** button alongside the existing Vercel button.

**[PandaStack](https://pandastack.io)** is a cloud deployment platform — supports static sites, containerized apps, databases, cronjobs, and more. A great alternative hosting option for your users.

### What this adds
```
[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=databendlabs/link)
```

Happy to adjust build settings or output directory if needed. Feel free to close if you'd prefer to keep one button. 🙂